### PR TITLE
Enable Interrupts on DHT read timout

### DIFF
--- a/Arduino/UUGear/UUGear.ino
+++ b/Arduino/UUGear/UUGear.ino
@@ -572,6 +572,8 @@ void cmdReadDHT(String cmd) {
       while (digitalRead(pin) == (i & 1) ? HIGH : LOW) {
         age = micros() - startTime;
         if (age > 80) {
+          // allow interrupts now
+          interrupts();
           Serial.write(RESPONSE_START_CHAR);
           Serial.write(clientId);
           Serial.print("-1");


### PR DESCRIPTION
When it times out reading a DHT sensor it returns error -1 but does not enable interrupts again which locks up the arduino.